### PR TITLE
Rename project to rsm-bsa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.21)
 
 include("cmake/version.cmake")
 project(
-	bsa
+	rsm-bsa
 	VERSION "${BSA_VERSION_MAJOR}.${BSA_VERSION_MINOR}.${BSA_VERSION_PATCH}"
 	LANGUAGES CXX
 )


### PR DESCRIPTION
Without that change, vcpkg install fails :
`find_package(bsa CONFIG)` does not work, nor does `find_package(rsm-bsa CONFIG)`

With that change, we can use `find_package(rsm-bsa CONFIG)`

If you don't want to make that change, I can instead make it as a vcpkg patch