### PR TITLE
Minor code fix to make library compatible with DirectXTex October 2024

### DIFF
--- a/src/bsa/fo4.cpp
+++ b/src/bsa/fo4.cpp
@@ -677,7 +677,7 @@ namespace bsa::fo4
 		}
 
 		a_out.write_bytes({ //
-			static_cast<const std::byte*>(blob.GetBufferPointer()),
+			reinterpret_cast<const std::byte*>(blob.GetBufferPointer()),
 			blob.GetBufferSize() });
 		std::vector<std::byte> buffer;
 		for (const auto& chunk : *this) {


### PR DESCRIPTION
The October 2024 release of DirectXTex changed `void*` to `uint8_t*` usage for buffers. This breaks ``std::byte*`` usage.

A hotfix is being made for the library to fix this and the next version includes the updates, but a minor tweak is needed to this library to work. It should be compatible with both the old and new version.